### PR TITLE
chore: removed source map reference

### DIFF
--- a/dist/picker.js
+++ b/dist/picker.js
@@ -1594,4 +1594,3 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ ])
 });
 ;
-//# sourceMappingURL=picker.js.map


### PR DESCRIPTION
Fixes webpack warnings.

Issue: https://github.com/fengyuanchen/pickerjs/issues/5