### PR TITLE
fix: use current date to calculate the max days

### DIFF
--- a/src/js/picker.js
+++ b/src/js/picker.js
@@ -190,7 +190,7 @@ class Picker {
           break;
 
         case 'D':
-          data.max = () => getDaysInMonth(date.getFullYear(), date.getMonth());
+          data.max = () => getDaysInMonth(this.date.getFullYear(), this.date.getMonth());
           data.min = 1;
           break;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](https://github.com/fengyuanchen/pickerjs/blob/master/.github/CONTRIBUTING.md#commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update
[ ] Refactor
[ ] Build related changes
[ ] Documentation content changes
[ ] Other, Please describe:
```


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When a date is set when instantiating a Picker class, the last date of the month will be stuck to the value of the current date of the user's clock.
If the current month is February and I call `picker.setDate` with any date, the day column will be 01-28 no matter the month I choose.

https://codepen.io/anon/pen/YBZjjO

Issue Number: N/A


## What is the new behavior?
This PR fixes the issue by explicitly getting the class' `date` attribute. The previous code would capture the default `date` reference into the arrow function.

https://github.com/fengyuanchen/pickerjs/blob/b95bca4dc84ede04df862d68d69e229153201e7e/src/js/methods.js#L224-L231

The `setDate` method replaces the `date` attribute with the reference passed by argument. As the arrow function captured the reference at declaration, it will keep using the default date even if it's not valid anymore.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
